### PR TITLE
Add support for Carthage

### DIFF
--- a/Demo/Pods/Moya/Sources/Moya/MoyaAvailability.swift
+++ b/Demo/Pods/Moya/Sources/Moya/MoyaAvailability.swift
@@ -39,5 +39,5 @@ extension PluginType {
     func willSendRequest(request: RequestType, target: TargetType) { fatalError() }
 
     @available(*, unavailable, renamed: "didReceive(_:)")
-    func didReceiveResponse(result: Result<Moya.Response, Moya.Error>, target: TargetType) { fatalError() }
+    func didReceiveResponse(result: Result<Moya.Response, MoyaError>, target: TargetType) { fatalError() }
 }

--- a/Demo/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Moya-ModelMapper.xcscheme
+++ b/Demo/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Moya-ModelMapper.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "14939B031C689B9F007DCCF6"
-               BuildableName = "Demo.app"
-               BlueprintName = "Demo"
-               ReferencedContainer = "container:Demo.xcodeproj">
+               BlueprintIdentifier = "7524549ED5DC7B6D56990100D1A9D69B"
+               BuildableName = "Moya_ModelMapper.framework"
+               BlueprintName = "Moya-ModelMapper"
+               ReferencedContainer = "container:Pods.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -29,15 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "14939B031C689B9F007DCCF6"
-            BuildableName = "Demo.app"
-            BlueprintName = "Demo"
-            ReferencedContainer = "container:Demo.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -51,16 +42,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "14939B031C689B9F007DCCF6"
-            BuildableName = "Demo.app"
-            BlueprintName = "Demo"
-            ReferencedContainer = "container:Demo.xcodeproj">
+            BlueprintIdentifier = "7524549ED5DC7B6D56990100D1A9D69B"
+            BuildableName = "Moya_ModelMapper.framework"
+            BlueprintName = "Moya-ModelMapper"
+            ReferencedContainer = "container:Pods.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -70,16 +60,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "14939B031C689B9F007DCCF6"
-            BuildableName = "Demo.app"
-            BlueprintName = "Demo"
-            ReferencedContainer = "container:Demo.xcodeproj">
+            BlueprintIdentifier = "7524549ED5DC7B6D56990100D1A9D69B"
+            BuildableName = "Moya_ModelMapper.framework"
+            BlueprintName = "Moya-ModelMapper"
+            ReferencedContainer = "container:Pods.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
Pretty straightforward.

A user can just install this by pointing at the repo in their `Cartfile`, no other special effort required.

You can test it with the line: `github 'bbqsrc/Moya-ModelMapper' 'carthage'`

Let me know if I broke Pod support however.