### PR TITLE
Implements Mapper error rethrowing

### DIFF
--- a/Sources/Moya-ModelMapper/Response+ModelMapper.swift
+++ b/Sources/Moya-ModelMapper/Response+ModelMapper.swift
@@ -13,42 +13,56 @@ import Mapper
 public extension Response {
     
     public func mapObject<T: Mappable>() throws -> T {
-        guard let jsonDictionary = try mapJSON() as? NSDictionary, let object = T.from(jsonDictionary) else {
+        guard let jsonDictionary = try mapJSON() as? NSDictionary else {
             throw MoyaError.jsonMapping(self)
         }
-        
-        return object
+
+        do {
+            return try T(map: Mapper(JSON: jsonDictionary))
+        } catch {
+            throw MoyaError.underlying(error)
+        }
     }
     
     public func mapObject<T: Mappable>(withKeyPath keyPath: String?) throws -> T {
         guard let keyPath = keyPath else { return try mapObject() }
         
         guard let jsonDictionary = try mapJSON() as? NSDictionary,
-            let objectDictionary = jsonDictionary.value(forKeyPath:keyPath) as? NSDictionary,
-            let object = T.from(objectDictionary) else {
+            let objectDictionary = jsonDictionary.value(forKeyPath:keyPath) as? NSDictionary else {
                 throw MoyaError.jsonMapping(self)
         }
-        
-        return object
+
+        do {
+            return try T(map: Mapper(JSON: objectDictionary))
+        } catch {
+            throw MoyaError.underlying(error)
+        }
     }
     
     public func mapArray<T: Mappable>() throws -> [T] {
-        guard let jsonArray = try mapJSON() as? NSArray, let object = T.from(jsonArray) else {
+        guard let jsonArray = try mapJSON() as? [NSDictionary] else {
             throw MoyaError.jsonMapping(self)
         }
-        
-        return object
+
+        do {
+            return try jsonArray.map { try T(map: Mapper(JSON: $0)) }
+        } catch {
+            throw MoyaError.underlying(error)
+        }
     }
     
     public func mapArray<T: Mappable>(withKeyPath keyPath: String?) throws -> [T] {
         guard let keyPath = keyPath else { return try mapArray() }
         
         guard let jsonDictionary = try mapJSON() as? NSDictionary,
-            let objectArray = jsonDictionary.value(forKeyPath:keyPath) as? NSArray,
-            let object = T.from(objectArray) else {
+            let objectArray = jsonDictionary.value(forKeyPath:keyPath) as? [NSDictionary] else {
                 throw MoyaError.jsonMapping(self)
         }
-        
-        return object
+
+        do {
+            return try objectArray.map { try T(map: Mapper(JSON: $0)) }
+        } catch {
+            throw MoyaError.underlying(error)
+        }
     }
 }


### PR DESCRIPTION
In this PR I've implemented the error handling proposed in #38. From now on, the errors thrown by Mapper are rethrown as associated value of `MoyaError.underlying`. If the response body is not a valid JSON object or it does not have expected format (e.g. object when you expect array), the `MoyaError.jsonMapping` is thrown as before.